### PR TITLE
[codex] Package LaWallet NWC for Umbrel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.umbrel-local/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,53 @@
-## LaWallet Umbrel Community App Store
+# LaWallet Umbrel Community App Store
 
-This repository is a template to create an LaWallet Umbrel Community App Store. These additional app stores allow developers to distribute applications without submitting to the [Official Umbrel App Store](https://github.com/getumbrel/umbrel-apps).
+This repository packages [LaWallet NWC](https://github.com/lawalletio/lawallet-nwc)
+as an Umbrel community app.
 
-## How to use:
+## App
 
-To use your Community App Store, you can add its GitHub url the umbrelOS user interface as shown in the following demo:
+- App id: `lawallet-nwc`
+- App entrypoint: `/admin/`
+- Published image: `masize/lawallet-nwc:1.0.0`
+- Internal port: `2288`
+- Health check: `GET /api/health`
+- Runtime data: PostgreSQL persisted in `${APP_DATA_DIR}/data/postgres`
+- Umbrel dependency: `albyhub`, used as the local NWC provider during setup
 
-https://user-images.githubusercontent.com/10330103/197889452-e5cd7e96-3233-4a09-b475-94b754adc7a3.mp4
+## Local Smoke Test
+
+Run the app with local Postgres, Bitcoin Core regtest, and LND regtest:
+
+```bash
+./scripts/smoke-local.sh
+```
+
+The script leaves the stack running when successful.
+
+Default local endpoints:
+
+- LaWallet admin: http://127.0.0.1:2289/admin
+- LaWallet health: http://127.0.0.1:2289/api/health
+- Bitcoin regtest RPC: `127.0.0.1:18443`, user `umbrel`, password `umbrel`
+- LND regtest gRPC: `127.0.0.1:10009`
+- LND regtest REST: `127.0.0.1:18080`
+
+Local state is written to `.umbrel-local/lawallet-nwc/` and ignored by git.
+
+To stop the local stack:
+
+```bash
+docker compose --project-name lawallet-nwc-local --file test/docker-compose.regtest.yml down
+```
+
+To reset the local stack:
+
+```bash
+docker compose --project-name lawallet-nwc-local --file test/docker-compose.regtest.yml down
+rm -rf .umbrel-local/lawallet-nwc
+./scripts/smoke-local.sh
+```
+
+## Using The Community App Store
+
+Add this repository URL as a community app store in the umbrelOS UI, then install
+`LaWallet NWC`.

--- a/lawallet-nwc/docker-compose.yml
+++ b/lawallet-nwc/docker-compose.yml
@@ -1,31 +1,43 @@
-version: "3.8"
+version: "3.7"
 
 services:
   app_proxy:
     environment:
-      APP_HOST: lawallet-nwc_1
-      APP_PORT: 9877
+      APP_HOST: lawallet-nwc_web_1
+      APP_PORT: 2288
       PROXY_AUTH_ADD: "false"
-  lawallet-nwc:
-    container_name: lawallet-nwc_1
-    image: masize/lawallet-nwc:0.7.0
+
+  web:
+    image: masize/lawallet-nwc:1.0.0
     environment:
       NODE_ENV: production
-      DATABASE_URL: "postgresql://root:root@postgres/lawallet-nwc"
-      PORT: 9877
+      PORT: 2288
+      DATABASE_URL: "postgresql://lawallet:${APP_PASSWORD}@postgres:5432/lawallet"
+      JWT_SECRET: "${APP_SEED}"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     restart: "on-failure"
     stop_grace_period: "1m"
     init: true
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS \"http://$$(hostname -i):2288/api/health\" >/dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
+
   postgres:
-    image: postgres:15
-    restart: always
+    image: postgres:15-alpine
+    restart: "on-failure"
     environment:
-      POSTGRES_USER: root
-      POSTGRES_PASSWORD: root
-      POSTGRES_DB: lawallet-nwc
-    ports:
-      - 5432:5432
+      POSTGRES_USER: lawallet
+      POSTGRES_PASSWORD: "${APP_PASSWORD}"
+      POSTGRES_DB: lawallet
     volumes:
       - "${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U lawallet -d lawallet"]
+      interval: 10s
+      timeout: 5s
+      retries: 10

--- a/lawallet-nwc/umbrel-app.yml
+++ b/lawallet-nwc/umbrel-app.yml
@@ -2,23 +2,31 @@ manifestVersion: 1
 id: lawallet-nwc
 category: bitcoin
 name: LaWallet NWC
-version: "0.7.0"
-tagline: LaWallet Backend
-icon: https://raw.githubusercontent.com/lawalletio/ledger/refs/heads/main/umbrel-app/public/icon.png
+version: "1.0.0"
+tagline: Lightning Address platform and Nostr CRM
+icon: https://raw.githubusercontent.com/lawalletio/lawallet-nwc/main/apps/web/public/logos/lawallet.png
 description: >-
-  LaWallet NWC merges Lightning Address, Boltcard and NWC, providing a PWA wallet for end-users and admin dashboard for managing.
+  LaWallet NWC is an open-source platform for creating, managing, and serving
+  Lightning Addresses connected to Nostr Wallet Connect. It includes an admin
+  dashboard for operators, a user wallet, BoltCard workflows, and NWC-based
+  routing for Lightning payments.
 developer: La Crypta
 website: https://lawallet.io
 dependencies:
   - albyhub
 repo: https://github.com/lawalletio/lawallet-nwc
 support: https://t.me/lacryptaok
-port: 9877
+port: 2288
 gallery:
-  - https://raw.githubusercontent.com/lawalletio/ledger/refs/heads/main/umbrel-app/public/3.png
-path: ""
+  - https://raw.githubusercontent.com/lawalletio/lawallet-nwc/main/apps/web/public/mobile-wallet-connect.png
+  - https://raw.githubusercontent.com/lawalletio/lawallet-nwc/main/apps/web/public/images/onboarding-hero.jpg
+path: /admin/
 defaultUsername: ""
 defaultPassword: ""
 submitter: Agustin Kassis
 submission: https://github.com/getumbrel/umbrel/pull/566
-releaseNotes: ""
+releaseNotes: >-
+  Initial Umbrel packaging for LaWallet NWC 1.0.0. The app runs the published
+  LaWallet web image, persists PostgreSQL data under the Umbrel app data
+  directory, opens directly to /admin, and exposes a Docker health check backed
+  by /api/health.

--- a/scripts/smoke-local.sh
+++ b/scripts/smoke-local.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_NAME="${PROJECT_NAME:-lawallet-nwc-local}"
+COMPOSE_FILE="${ROOT_DIR}/test/docker-compose.regtest.yml"
+
+export LOCAL_APP_DATA_DIR="${LOCAL_APP_DATA_DIR:-${ROOT_DIR}/.umbrel-local/lawallet-nwc}"
+export APP_SEED="${APP_SEED:-lawallet-local-jwt-secret-at-least-32-chars}"
+export APP_PASSWORD="${APP_PASSWORD:-lawallet-local-password}"
+export LAWALLET_PORT="${LAWALLET_PORT:-2289}"
+
+mkdir -p "${LOCAL_APP_DATA_DIR}"
+
+docker compose --project-name "${PROJECT_NAME}" --file "${COMPOSE_FILE}" up --detach bitcoin lnd postgres lawallet-nwc
+
+lawallet_ready=false
+for attempt in $(seq 1 120); do
+  if response="$(curl -fsS "http://127.0.0.1:${LAWALLET_PORT}/api/health" 2>/dev/null)" && \
+    printf "%s" "${response}" | grep -q '"status":"ok"'; then
+    lawallet_ready=true
+    break
+  fi
+  sleep 2
+done
+
+if [[ "${lawallet_ready}" != "true" ]]; then
+  echo "LaWallet health check did not pass in time." >&2
+  docker compose --project-name "${PROJECT_NAME}" --file "${COMPOSE_FILE}" logs --tail 200 postgres lawallet-nwc >&2
+  exit 1
+fi
+
+lnd_ready=false
+for attempt in $(seq 1 60); do
+  if lnd_info="$(docker compose --project-name "${PROJECT_NAME}" --file "${COMPOSE_FILE}" exec -T lnd \
+    lncli --network=regtest --rpcserver=localhost:10009 --tlscertpath=/root/.lnd/tls.cert getinfo 2>/dev/null)" && \
+    printf "%s" "${lnd_info}" | grep -q '"synced_to_chain": true'; then
+    lnd_ready=true
+    break
+  fi
+  sleep 2
+done
+
+if [[ "${lnd_ready}" != "true" ]]; then
+  echo "LND regtest check did not pass in time." >&2
+  docker compose --project-name "${PROJECT_NAME}" --file "${COMPOSE_FILE}" logs --tail 200 bitcoin lnd >&2
+  exit 1
+fi
+
+echo "LaWallet health check passed: ${response}"
+echo "LND regtest check passed."
+echo "Admin UI: http://127.0.0.1:${LAWALLET_PORT}/admin"
+echo "Bitcoin regtest RPC: 127.0.0.1:${BITCOIN_RPC_PORT:-18443} user=umbrel password=umbrel"
+echo "LND regtest ports: grpc=${LND_GRPC_PORT:-10009} rest=${LND_REST_PORT:-18080}"

--- a/test/docker-compose.regtest.yml
+++ b/test/docker-compose.regtest.yml
@@ -1,0 +1,109 @@
+services:
+  bitcoin:
+    image: ghcr.io/getumbrel/docker-bitcoind:v30.2@sha256:75ad7da4eaa2a56b92e5703ff39fa86aa7b9012c50749ca082f018a761d136cd
+    restart: unless-stopped
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        rm -f /data/.bitcoin/regtest/.ready
+        bitcoind -regtest \
+          -server=1 \
+          -rpcbind=0.0.0.0 \
+          -rpcallowip=0.0.0.0/0 \
+          -rpcuser=umbrel \
+          -rpcpassword=umbrel \
+          -rpcport=18443 \
+          -txindex=1 \
+          -fallbackfee=0.00001 \
+          -disablewallet=0 \
+          -zmqpubrawblock=tcp://0.0.0.0:28332 \
+          -zmqpubrawtx=tcp://0.0.0.0:28333 &
+        BITCOIND_PID=$$!
+        until bitcoin-cli -regtest -rpcuser=umbrel -rpcpassword=umbrel getblockchaininfo >/dev/null 2>&1; do sleep 1; done
+        bitcoin-cli -regtest -rpcuser=umbrel -rpcpassword=umbrel createwallet "regtest_wallet" 2>/dev/null || \
+          bitcoin-cli -regtest -rpcuser=umbrel -rpcpassword=umbrel loadwallet "regtest_wallet" 2>/dev/null || true
+        bitcoin-cli -regtest -rpcuser=umbrel -rpcpassword=umbrel -rpcwallet=regtest_wallet -generate 101 >/dev/null 2>&1 || true
+        touch /data/.bitcoin/regtest/.ready
+        wait $$BITCOIND_PID
+    ports:
+      - "${BITCOIN_RPC_PORT:-18443}:18443"
+    volumes:
+      - "${LOCAL_APP_DATA_DIR:-./.umbrel-local/lawallet-nwc}/bitcoin:/data/.bitcoin"
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /data/.bitcoin/regtest/.ready && bitcoin-cli -regtest -rpcuser=umbrel -rpcpassword=umbrel getblockchaininfo >/dev/null"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  lnd:
+    image: lightninglabs/lnd:v0.20.1-beta@sha256:f0a2bdc4b8bc89cb3b31b6e12d6b16ac5145defd916d8152cf0c1c07d8697cff
+    restart: unless-stopped
+    command:
+      - --bitcoin.active
+      - --bitcoin.regtest
+      - --bitcoin.node=bitcoind
+      - --bitcoind.rpchost=bitcoin:18443
+      - --bitcoind.rpcuser=umbrel
+      - --bitcoind.rpcpass=umbrel
+      - --bitcoind.zmqpubrawblock=tcp://bitcoin:28332
+      - --bitcoind.zmqpubrawtx=tcp://bitcoin:28333
+      - --rpclisten=0.0.0.0:10009
+      - --restlisten=0.0.0.0:8080
+      - --listen=0.0.0.0:9735
+      - --tlsextradomain=lnd
+      - --tlsextradomain=localhost
+      - --tlsextraip=127.0.0.1
+      - --noseedbackup
+      - --nobootstrap
+    ports:
+      - "${LND_GRPC_PORT:-10009}:10009"
+      - "${LND_REST_PORT:-18080}:8080"
+      - "${LND_P2P_PORT:-9735}:9735"
+    volumes:
+      - "${LOCAL_APP_DATA_DIR:-./.umbrel-local/lawallet-nwc}/lnd:/root/.lnd"
+    depends_on:
+      bitcoin:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "lncli --network=regtest --rpcserver=localhost:10009 --tlscertpath=/root/.lnd/tls.cert getinfo >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: lawallet
+      POSTGRES_PASSWORD: "${APP_PASSWORD:-lawallet-local-password}"
+      POSTGRES_DB: lawallet
+    volumes:
+      - "${LOCAL_APP_DATA_DIR:-./.umbrel-local/lawallet-nwc}/postgres:/var/lib/postgresql/data"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U lawallet -d lawallet"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  lawallet-nwc:
+    image: masize/lawallet-nwc:1.0.0
+    restart: unless-stopped
+    init: true
+    environment:
+      NODE_ENV: production
+      PORT: 2288
+      DATABASE_URL: "postgresql://lawallet:${APP_PASSWORD:-lawallet-local-password}@postgres:5432/lawallet"
+      JWT_SECRET: "${APP_SEED:-lawallet-local-jwt-secret-at-least-32-chars}"
+    ports:
+      - "${LAWALLET_PORT:-2289}:2288"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS \"http://$$(hostname -i):2288/api/health\" >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s


### PR DESCRIPTION
## Summary

- Updates the LaWallet NWC Umbrel app to the published `masize/lawallet-nwc:1.0.0` image on port `2288`.
- Points Umbrel directly at `/admin/`, persists Postgres under `${APP_DATA_DIR}`, and adds web/Postgres health checks.
- Adds a local regtest smoke stack with Bitcoin Core, LND, Postgres, and LaWallet plus documentation for running and resetting it.

## Validation

- Parsed all YAML files with Ruby `YAML.load_file`.
- Rendered the Umbrel-merged compose using Umbrel's `app_proxy` and common compose fragments.
- Ran `./scripts/smoke-local.sh` successfully.
- Confirmed LaWallet returned `{"status":"ok","service":"web","database":"up"}`.
- Confirmed LND regtest reported `synced_to_chain: true` on `regtest` at block height 101.
- Confirmed `/admin` returns the LaWallet admin HTML page.

## Notes

The full local Umbrel OS/dev VM is not part of this PR. The included smoke stack provides the reproducible local regtest environment for testing this app package.