### PR TITLE
[codex] Add LaWallet NWC package updater workflow

### DIFF
--- a/.github/workflows/update-lawallet-nwc.yml
+++ b/.github/workflows/update-lawallet-nwc.yml
@@ -1,0 +1,162 @@
+name: Update LaWallet NWC
+
+on:
+  repository_dispatch:
+    types: [lawallet-nwc-release]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "LaWallet NWC version to package, with or without a leading v"
+        required: true
+        type: string
+      image:
+        description: "Full Docker image tag. Defaults to masize/lawallet-nwc:<version>."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-lawallet-nwc-${{ github.event.client_payload.version || inputs.version || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update Umbrel package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Resolve package inputs
+        id: package
+        env:
+          DISPATCH_VERSION: ${{ github.event.client_payload.version }}
+          DISPATCH_IMAGE: ${{ github.event.client_payload.image }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_IMAGE: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${DISPATCH_VERSION:-${INPUT_VERSION:-}}"
+          VERSION="${VERSION#v}"
+          if [ -z "${VERSION}" ]; then
+            echo "::error::Missing LaWallet NWC version."
+            exit 1
+          fi
+
+          IMAGE="${DISPATCH_IMAGE:-${INPUT_IMAGE:-}}"
+          if [ -z "${IMAGE}" ]; then
+            IMAGE="masize/lawallet-nwc:${VERSION}"
+          fi
+
+          BRANCH_VERSION="$(printf "%s" "${VERSION}" | tr -cd "0-9A-Za-z._-")"
+          {
+            echo "version=${VERSION}"
+            echo "image=${IMAGE}"
+            echo "branch=automation/lawallet-nwc-${BRANCH_VERSION}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Update package files
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+          IMAGE: ${{ steps.package.outputs.image }}
+        run: |
+          set -euo pipefail
+
+          python3 <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          image = os.environ["IMAGE"]
+
+          def replace_once(path, pattern, replacement):
+              file_path = Path(path)
+              original = file_path.read_text()
+              updated, count = re.subn(pattern, replacement, original, count=1, flags=re.MULTILINE)
+              if count != 1:
+                  raise SystemExit(f"Expected exactly one match in {path}, found {count}")
+              file_path.write_text(updated)
+
+          replace_once(
+              "lawallet-nwc/umbrel-app.yml",
+              r"^version:\s*.*$",
+              lambda match: f'version: "{version}"',
+          )
+
+          for compose_file in ("lawallet-nwc/docker-compose.yml", "test/docker-compose.regtest.yml"):
+              replace_once(
+                  compose_file,
+                  r"^(\s+image:\s+)masize/lawallet-nwc:[^\s]+$",
+                  lambda match: f"{match.group(1)}{image}",
+              )
+
+          replace_once(
+              "README.md",
+              r"^(- Published image: `)masize/lawallet-nwc:[^`]+(`)$",
+              lambda match: f"{match.group(1)}{image}{match.group(2)}",
+          )
+          PY
+
+          grep -n 'version:' lawallet-nwc/umbrel-app.yml
+          grep -RIn 'image: masize/lawallet-nwc:' lawallet-nwc/docker-compose.yml test/docker-compose.regtest.yml
+          grep -n 'Published image:' README.md
+
+      - name: Open package update pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.package.outputs.version }}
+          IMAGE: ${{ steps.package.outputs.image }}
+          BRANCH: ${{ steps.package.outputs.branch }}
+          SOURCE_REPOSITORY: ${{ github.event.client_payload.source_repository }}
+          SOURCE_RUN_URL: ${{ github.event.client_payload.source_run_url }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet; then
+            echo "LaWallet NWC package is already up to date."
+            exit 0
+          fi
+
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "${BRANCH}"
+          git add README.md lawallet-nwc/umbrel-app.yml lawallet-nwc/docker-compose.yml test/docker-compose.regtest.yml
+          git commit -m "Update LaWallet NWC to ${VERSION}"
+          git push --force-with-lease origin "${BRANCH}"
+
+          BODY_FILE="$(mktemp)"
+          {
+            echo "Updates the Umbrel package for LaWallet NWC ${VERSION}."
+            echo
+            echo "- Sets the Umbrel app version to ${VERSION}"
+            echo "- Updates Docker image references to ${IMAGE}"
+            echo "- Keeps the local regtest smoke stack on the same image tag"
+            if [ -n "${SOURCE_REPOSITORY}" ]; then
+              echo
+              echo "Triggered by ${SOURCE_REPOSITORY}."
+            fi
+            if [ -n "${SOURCE_RUN_URL}" ]; then
+              echo "Source run: ${SOURCE_RUN_URL}"
+            fi
+          } > "${BODY_FILE}"
+
+          if gh pr view "${BRANCH}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh pr edit "${BRANCH}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "Update LaWallet NWC to ${VERSION}" \
+              --body-file "${BODY_FILE}"
+          else
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --base master \
+              --head "${BRANCH}" \
+              --title "Update LaWallet NWC to ${VERSION}" \
+              --body-file "${BODY_FILE}"
+          fi


### PR DESCRIPTION
Adds a GitHub Actions receiver for LaWallet NWC release notifications.

What changed:
- Adds `repository_dispatch` handling for `lawallet-nwc-release`
- Supports manual `workflow_dispatch` for a specific version/image
- Updates the Umbrel app version, Docker image references, README image tag, and local regtest image tag
- Opens or updates an app-store PR for the package bump

Validation:
- Parsed workflow YAML locally
- Ran `git diff --check`
- Dry-ran the updater logic against a temporary copy and confirmed the manifest, compose files, and README were updated

This pairs with the sender PR in `lawalletio/lawallet-nwc`.
