### PR TITLE
[codex] Auto merge LaWallet package updates

### DIFF
--- a/.github/workflows/update-lawallet-nwc.yml
+++ b/.github/workflows/update-lawallet-nwc.yml
@@ -107,7 +107,7 @@ jobs:
           grep -RIn 'image: masize/lawallet-nwc:' lawallet-nwc/docker-compose.yml test/docker-compose.regtest.yml
           grep -n 'Published image:' README.md
 
-      - name: Open package update pull request
+      - name: Open and merge package update pull request
         env:
           GH_TOKEN: ${{ secrets.UMBREL_APP_STORE_UPDATE_TOKEN }}
           VERSION: ${{ steps.package.outputs.version }}
@@ -166,3 +166,13 @@ jobs:
               --title "Update LaWallet NWC to ${VERSION}" \
               --body-file "${BODY_FILE}"
           fi
+
+          PR_URL="$(gh pr view "${BRANCH}" --repo "${GITHUB_REPOSITORY}" --json url --jq .url)"
+          echo "Merging ${PR_URL}"
+
+          gh pr merge "${PR_URL}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --squash \
+            --delete-branch \
+            --subject "Update LaWallet NWC to ${VERSION}" \
+            --body "Automated Umbrel package update for ${IMAGE}."


### PR DESCRIPTION
Updates the LaWallet NWC package updater so release-triggered package bump PRs are merged automatically.

What changed:
- Renames the final workflow step to `Open and merge package update pull request`.
- After creating or updating the package bump PR, resolves its URL.
- Squash-merges that PR into `master` with `gh pr merge`.
- Deletes the automation branch after merge.

Operational notes:
- This uses the existing `UMBREL_APP_STORE_UPDATE_TOKEN` secret.
- The token needs enough access to push the automation branch, open/update the PR, and merge it: `Contents: Read and write` plus `Pull requests: Read and write` on `lawalletio/umbrel-app-store`.
- If branch protection later requires manual review or required checks that cannot pass, GitHub will block the merge and the workflow will fail instead of silently leaving an unmerged update.

Validation:
- Parsed workflow YAML locally.
- Ran `git diff --check`.
