### PR TITLE
Update LaWallet NWC to 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ as an Umbrel community app.
 
 - App id: `lawallet-nwc`
 - App entrypoint: `/admin/`
-- Published image: `masize/lawallet-nwc:1.0.0`
+- Published image: `masize/lawallet-nwc:1.0.2`
 - Internal port: `2288`
 - Health check: `GET /api/health`
 - Runtime data: PostgreSQL persisted in `${APP_DATA_DIR}/data/postgres`

--- a/lawallet-nwc/docker-compose.yml
+++ b/lawallet-nwc/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   web:
-    image: masize/lawallet-nwc:1.0.0
+    image: masize/lawallet-nwc:1.0.2
     environment:
       NODE_ENV: production
       PORT: 2288

--- a/lawallet-nwc/umbrel-app.yml
+++ b/lawallet-nwc/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lawallet-nwc
 category: bitcoin
 name: LaWallet NWC
-version: "1.0.0"
+version: "1.0.2"
 tagline: Lightning Address platform and Nostr CRM
 icon: https://github.com/lawalletio/lawallet-nwc/blob/main/apps/web/public/logos/lawallet-iso.png?raw=true
 description: >-

--- a/test/docker-compose.regtest.yml
+++ b/test/docker-compose.regtest.yml
@@ -88,7 +88,7 @@ services:
       retries: 20
 
   lawallet-nwc:
-    image: masize/lawallet-nwc:1.0.0
+    image: masize/lawallet-nwc:1.0.2
     restart: unless-stopped
     init: true
     environment:


### PR DESCRIPTION
Updates the Umbrel package for LaWallet NWC 1.0.2.

- Sets the Umbrel app version to 1.0.2
- Updates Docker image references to masize/lawallet-nwc:1.0.2
- Keeps the local regtest smoke stack on the same image tag

Completed manually: the automated dispatch/update tokens (UMBREL_APP_STORE_DISPATCH_TOKEN, UMBREL_APP_STORE_UPDATE_TOKEN) lack Contents:write on this repo (HTTP 403). Image masize/lawallet-nwc:1.0.2 is published on Docker Hub.