### PR TITLE
Update LaWallet NWC to 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ as an Umbrel community app.
 
 - App id: `lawallet-nwc`
 - App entrypoint: `/admin/`
-- Published image: `masize/lawallet-nwc:1.0.2`
+- Published image: `masize/lawallet-nwc:1.0.3`
 - Internal port: `2288`
 - Health check: `GET /api/health`
 - Runtime data: PostgreSQL persisted in `${APP_DATA_DIR}/data/postgres`

--- a/lawallet-nwc/docker-compose.yml
+++ b/lawallet-nwc/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   web:
-    image: masize/lawallet-nwc:1.0.2
+    image: masize/lawallet-nwc:1.0.3
     environment:
       NODE_ENV: production
       PORT: 2288

--- a/lawallet-nwc/umbrel-app.yml
+++ b/lawallet-nwc/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lawallet-nwc
 category: bitcoin
 name: LaWallet NWC
-version: "1.0.2"
+version: "1.0.3"
 tagline: Lightning Address platform and Nostr CRM
 icon: https://github.com/lawalletio/lawallet-nwc/blob/main/apps/web/public/logos/lawallet-iso.png?raw=true
 description: >-

--- a/test/docker-compose.regtest.yml
+++ b/test/docker-compose.regtest.yml
@@ -88,7 +88,7 @@ services:
       retries: 20
 
   lawallet-nwc:
-    image: masize/lawallet-nwc:1.0.2
+    image: masize/lawallet-nwc:1.0.3
     restart: unless-stopped
     init: true
     environment:


### PR DESCRIPTION
Updates the Umbrel package for LaWallet NWC 1.0.3 (image masize/lawallet-nwc:1.0.3, published on Docker Hub).

Completed manually — the automated UMBREL_APP_STORE_DISPATCH_TOKEN still lacks Contents:write on this repo (HTTP 403 on repository_dispatch).