### PR TITLE
Update LaWallet NWC to 1.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ as an Umbrel community app.
 
 - App id: `lawallet-nwc`
 - App entrypoint: `/admin/`
-- Published image: `masize/lawallet-nwc:1.0.9`
+- Published image: `masize/lawallet-nwc:1.0.10`
 - Internal port: `2288`
 - Health check: `GET /api/health`
 - Runtime data: PostgreSQL persisted in `${APP_DATA_DIR}/data/postgres`

--- a/lawallet-nwc/docker-compose.yml
+++ b/lawallet-nwc/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   web:
-    image: masize/lawallet-nwc:1.0.9
+    image: masize/lawallet-nwc:1.0.10
     environment:
       NODE_ENV: production
       PORT: 2288

--- a/lawallet-nwc/umbrel-app.yml
+++ b/lawallet-nwc/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: lawallet-nwc
 category: bitcoin
 name: LaWallet NWC
-version: "1.0.9"
+version: "1.0.10"
 tagline: Lightning Address platform and Nostr CRM
 icon: https://github.com/lawalletio/lawallet-nwc/blob/main/apps/web/public/logos/lawallet-iso.png?raw=true
 description: >-
@@ -27,6 +27,6 @@ defaultPassword: ""
 submitter: Agustin Kassis
 submission: https://github.com/getumbrel/umbrel/pull/566
 releaseNotes: |-
-  LaWallet NWC 1.0.9.
+  LaWallet NWC 1.0.10.
 
-  Full release notes: https://github.com/lawalletio/lawallet-nwc/releases/tag/v1.0.9
+  Full release notes: https://github.com/lawalletio/lawallet-nwc/releases/tag/v1.0.10

--- a/test/docker-compose.regtest.yml
+++ b/test/docker-compose.regtest.yml
@@ -88,7 +88,7 @@ services:
       retries: 20
 
   lawallet-nwc:
-    image: masize/lawallet-nwc:1.0.9
+    image: masize/lawallet-nwc:1.0.10
     restart: unless-stopped
     init: true
     environment:


### PR DESCRIPTION
Updates the Umbrel package for LaWallet NWC 1.0.10.

- Sets the Umbrel app version to 1.0.10
- Updates Docker image references to masize/lawallet-nwc:1.0.10
- Keeps the local regtest smoke stack on the same image tag

Triggered by lawalletio/lawallet-nwc.
Source run: https://github.com/lawalletio/lawallet-nwc/actions/runs/28407149961
